### PR TITLE
Remove need for api key

### DIFF
--- a/src/apiCalls.tsx
+++ b/src/apiCalls.tsx
@@ -1,11 +1,6 @@
 import { Repo } from './components/App/App'
 import { cleanRepoData } from './dataCleaning'
 
-
-const authHeader = {
-  headers: { authorization: `token ${process.env.REACT_APP_GH_KEY}` }
-}
-
 const checkResponse = (response: any): any => {
   if (response.ok) {
     return response.json()
@@ -15,13 +10,13 @@ const checkResponse = (response: any): any => {
 }
 
 export const getRepos = (query: string, sort: string): Promise<Repo[]> => {
-  return fetch(`https://api.github.com/search/repositories?q=${query}&sort=${sort}`, authHeader)
+  return fetch(`https://api.github.com/search/repositories?q=${query}&sort=${sort}`)
     .then(response => checkResponse(response))
       .then(data => data.items.map((repo: any) => cleanRepoData(repo)))
 }
 
 export const getSingleRepo = (ownerName: string, name: string): Promise<Repo> => {
-  return fetch(`https://api.github.com/repos/${ownerName}/${name}`, authHeader)
+  return fetch(`https://api.github.com/repos/${ownerName}/${name}`)
     .then(response => checkResponse(response))
       .then(data => cleanRepoData(data))
 }


### PR DESCRIPTION
When I built this project I reflexively used a private GitHub API key, but the next day realized that I might not need one just for getting repo information. This branch is a version of the project that doesn't require a key. I made this change after turning the project in on 6/9 so I won't merge this branch into main.

Installation if you would prefer to use this branch:
- `git clone <repo>`
- `cd github-search`
- `npm install`
- `git fetch`
- `git checkout fix/remove-key`
- `npm start`
